### PR TITLE
[ API ] Entire endpoint change, Alarm delete/update

### DIFF
--- a/swServer/build.gradle
+++ b/swServer/build.gradle
@@ -31,8 +31,8 @@ dependencies {
     implementation 'io.springfox:springfox-swagger-ui:3.0.0'
     implementation 'com.fasterxml.jackson.core:jackson-core:2.13.4'
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.4'
-
-
+    implementation 'org.jetbrains:annotations:23.0.0'
+    implementation group: 'com.flipkart.zjsonpatch', name: 'zjsonpatch', version: '0.4.12'
 
 }
 

--- a/swServer/src/main/java/com/daelim/swserver/alarm/controller/AlarmController.java
+++ b/swServer/src/main/java/com/daelim/swserver/alarm/controller/AlarmController.java
@@ -3,15 +3,22 @@ package com.daelim.swserver.alarm.controller;
 import com.daelim.swserver.alarm.dto.AlarmDTO;
 import com.daelim.swserver.alarm.entity.Alarm;
 import com.daelim.swserver.alarm.repository.AlarmRepository;
-import com.daelim.swserver.auth.repository.UserRepository;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.flipkart.zjsonpatch.JsonPatch;
+import com.flipkart.zjsonpatch.JsonPatchApplicationException;
 import com.google.gson.JsonObject;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -22,49 +29,127 @@ import java.util.List;
 @RequiredArgsConstructor
 public class AlarmController {
 
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    static {
+        mapper.registerModule(new JavaTimeModule());
+        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+    }
+
     private final AlarmRepository alarmRepository;
-    private final UserRepository userRepository;
 
     @Operation(
             summary = "알람 조회",
             description = "알람 전체 조회"
     )
-    @GetMapping("search")
-    public String getAlarm(
-            // @CookieValue(name = "userid") String userid
-    ) throws JsonProcessingException {
-
-        // Optional<User> user = userRepository.findById(userid);
-
+    @ApiResponses({
+            @ApiResponse(code = 200, message = "조회된 엔티티", response = AlarmDTO.class),
+    })
+    @GetMapping
+    public ResponseEntity<String> getAlarm() throws JsonProcessingException {
         List<Alarm> alarms = alarmRepository.findAll();
 
-        ObjectMapper mapper = new ObjectMapper();
-        mapper.registerModule(new JavaTimeModule());
-        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
-
-        return mapper.writeValueAsString(alarms);
+        return ResponseEntity.ok(mapper.writeValueAsString(alarms));
     }
 
     @Operation(
             summary = "알람 추가",
-            description = "알람 추가 성공여부 상태 리턴 (success true/failed)"
+            description = "간단한 상태"
     )
-    @PostMapping("insert")
-    public String insertAlarm(@RequestBody AlarmDTO alarmDTO) {
-        JsonObject response = new JsonObject();
+    @ApiResponses({
+            @ApiResponse(code = 201, message = "생성 성공"),
+            @ApiResponse(code = 400, message = "예외 발생")
+    })
+    @ResponseStatus(value = HttpStatus.CREATED)
+    @PostMapping
+    public ResponseEntity<String> insertAlarm(@RequestBody @NotNull AlarmDTO alarmDTO) {
         log.info(alarmDTO.toString());
-        Alarm alarm = alarmDTO.toEntity();
+        Alarm alarm = alarmDTO.create();
         log.info(alarm.toString());
 
         try {
-            Alarm saveAlarm = alarmRepository.save(alarm);
-            response.addProperty("success", "true");
-        } catch (Exception e) {
-            response.addProperty("success", "failed");
-            response.addProperty("message", e.getMessage());
-        }
+            alarmRepository.save(alarm);
 
-        return response.toString();
+            JsonObject response = new JsonObject();
+            response.addProperty("message", "alarm created success: " + alarmDTO.getAlarmId());
+
+            return new ResponseEntity<>(response.toString(), HttpStatus.CREATED);
+        } catch (Exception e) {
+            JsonObject response = new JsonObject();
+            response.addProperty("message", e.getMessage());
+
+            return ResponseEntity.badRequest().body(response.toString());
+        }
+    }
+
+    @Operation(
+            summary = "알람 삭제",
+            description = "알람 삭제"
+    )
+    @ApiResponses({
+            @ApiResponse(code = 204, message = "삭제 성공"),
+            @ApiResponse(code = 422, message = "alarmId 의 알람이 존재하지 않음")
+    })
+    @ResponseStatus(value = HttpStatus.NO_CONTENT)
+    @DeleteMapping
+    public ResponseEntity<String> deleteAlarm(@RequestParam String alarmId) {
+        if (alarmRepository.existsById(alarmId)) {
+            alarmRepository.deleteById(alarmId);
+
+            return ResponseEntity.noContent().build();
+        } else {
+            JsonObject jsonObject = new JsonObject();
+            jsonObject.addProperty("message", "alarm with id %s is not exists".formatted(alarmId));
+
+            return ResponseEntity.unprocessableEntity().body(jsonObject.toString());
+        }
+    }
+
+    @Operation(
+            summary = "알람 데이터 업데이트",
+            description = "RFC6902(https://www.rfc-editor.org/rfc/rfc6902) 에 따른 Patch 구현"
+    )
+    @ApiResponses({
+            @ApiResponse(code = 200, message = "업데이트 성공"),
+            @ApiResponse(code = 400, message = "업데이트 실패, 데이터에 문제 감지"),
+            @ApiResponse(code = 422, message = "같은 id의 알람을 찾지 못함")
+    })
+    @PatchMapping
+    public ResponseEntity<String> updateAlarm(@NotNull String alarmId,
+                                              @NotNull String patch) {
+        if (alarmRepository.existsById(alarmId)) {
+            try {
+                applyPatch(alarmId, patch);
+            } catch (JsonPatchApplicationException | JsonProcessingException e) {
+                JsonObject jsonObject = new JsonObject();
+                jsonObject.addProperty("message", "failed to patch %s".formatted(alarmId));
+                jsonObject.addProperty("exception", e.getMessage());
+                jsonObject.addProperty("data", patch);
+
+                return ResponseEntity.badRequest().body(jsonObject.toString());
+            }
+
+            return ResponseEntity.ok().build();
+        } else {
+            JsonObject jsonObject = new JsonObject();
+            jsonObject.addProperty("message", "alarm with id %s is not exists".formatted(alarmId));
+            return ResponseEntity.unprocessableEntity()
+                    .body(jsonObject.toString());
+        }
+    }
+
+    private void applyPatch(@NotNull String alarmId,
+                            @NotNull String toPatchString) throws JsonProcessingException {
+        AlarmDTO originDto = alarmRepository.findById(alarmId).orElseThrow().toDto();
+        String originString = mapper.writeValueAsString(originDto);
+
+        final JsonNode origin = mapper.readValue(originString, JsonNode.class);
+        final JsonNode patch = mapper.readValue(toPatchString, JsonNode.class);
+
+        AlarmDTO toSave = mapper.treeToValue(JsonPatch.apply(patch, origin), AlarmDTO.class);
+        log.info(toSave.toString());
+
+        alarmRepository.saveAndFlush(toSave.toEntity());
     }
 
 }

--- a/swServer/src/main/java/com/daelim/swserver/alarm/dto/AlarmDTO.java
+++ b/swServer/src/main/java/com/daelim/swserver/alarm/dto/AlarmDTO.java
@@ -5,6 +5,7 @@ import com.daelim.swserver.mg.Days;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.Data;
 import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.lang.Nullable;
 
 import java.time.LocalTime;
 import java.util.UUID;
@@ -12,6 +13,9 @@ import java.util.UUID;
 @Data
 public class AlarmDTO {
 
+    @Nullable
+    @ApiModelProperty(value = "알람 ID")
+    private String alarmId;
     @ApiModelProperty(value = "알람 설정시간")
     @DateTimeFormat(pattern = "HH:mm")
     private LocalTime startTime;
@@ -20,11 +24,23 @@ public class AlarmDTO {
     @ApiModelProperty(value = "알람 반복여부")
     private boolean isRepeat;
 
-    public Alarm toEntity() {
+    public Alarm create() {
         String uuid = UUID.randomUUID().toString();
 
         return Alarm.builder()
                 .alarmId(uuid)
+                .startTime(startTime)
+                .days(days)
+                .isRepeat(isRepeat)
+                .build();
+    }
+
+    public Alarm toEntity() {
+        if (alarmId == null)
+            alarmId = UUID.randomUUID().toString();
+
+        return Alarm.builder()
+                .alarmId(alarmId)
                 .startTime(startTime)
                 .days(days)
                 .isRepeat(isRepeat)

--- a/swServer/src/main/java/com/daelim/swserver/alarm/entity/Alarm.java
+++ b/swServer/src/main/java/com/daelim/swserver/alarm/entity/Alarm.java
@@ -1,5 +1,6 @@
 package com.daelim.swserver.alarm.entity;
 
+import com.daelim.swserver.alarm.dto.AlarmDTO;
 import com.daelim.swserver.mg.Days;
 import lombok.*;
 import org.hibernate.Hibernate;
@@ -28,6 +29,16 @@ public class Alarm {
     private Days days;
     @Column(nullable = false)
     private boolean isRepeat;
+
+    public AlarmDTO toDto() {
+        AlarmDTO dto = new AlarmDTO();
+        dto.setAlarmId(alarmId);
+        dto.setStartTime(startTime);
+        dto.setDays(days);
+        dto.setRepeat(isRepeat);
+
+        return dto;
+    }
 
     @Override
     public boolean equals(Object o) {

--- a/swServer/src/main/java/com/daelim/swserver/auth/controller/UserController.java
+++ b/swServer/src/main/java/com/daelim/swserver/auth/controller/UserController.java
@@ -9,9 +9,11 @@ import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.extern.slf4j.Slf4j;
+import org.jetbrains.annotations.NotNull;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import springfox.documentation.annotations.ApiIgnore;
 
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletResponse;
@@ -33,122 +35,162 @@ public class UserController {
     }
 
     @Operation(
-            summary = "사용자 회원가입",
-            description = "회원가입 성공여부 상태 리턴 (success true/failed)"
+            summary = "사용자 회원 가입",
+            description = "회원 가입"
     )
     @ApiResponses({
-            @ApiResponse(code = 200, message = "API 정상 구동"),
+            @ApiResponse(code = 201, message = "회원 가입 완료"),
+            @ApiResponse(code = 422, message = "이미 해당 ID의 회원이 있음"),
             @ApiResponse(code = 500, message = "서버 에러")
     })
     @PostMapping("signin")
+    @ResponseStatus(value = HttpStatus.CREATED)
     @ResponseBody
-    public String signin(@RequestBody UserDTO userdto) throws NoSuchAlgorithmException {
-        JsonObject response = new JsonObject();
+    public ResponseEntity<String> signin(@RequestBody @NotNull UserDTO userdto) throws NoSuchAlgorithmException {
+
         Optional<User> tempUser = userRepository.findById(userdto.getUserId());
         userdto.setUserPassword(sha256.encrypt(userdto.getUserPassword()));
 
-        // Check Duplicate User
         if (tempUser.isPresent()) {
-            response.addProperty("success", "failed");
+            JsonObject response = new JsonObject();
             response.addProperty("message", "Duplicate user");
-            return response.toString();
+
+            return ResponseEntity.unprocessableEntity().body(response.toString());
         }
 
         User user = userdto.toEntity();
         try {
             log.info("User Register : " + user.getUserId());
-            User saveUser = userRepository.save(user);
-            response.addProperty("success", "true");
-        } catch (Exception e) {
-            response.addProperty("success", "failed");
-            response.addProperty("message", e.getMessage());
-        }
+            userRepository.save(user);
 
-        return response.toString();
+            return new ResponseEntity<>(HttpStatus.CREATED);
+        } catch (Exception e) {
+            JsonObject response = new JsonObject();
+
+            response.addProperty("message", e.getMessage());
+            return ResponseEntity.internalServerError().body(response.toString());
+        }
     }
 
     @Operation(
             summary = "사용자 로그인",
-            description = "로그인 성공여부 상태 리턴 (success true/failed)\n쿠키 발급 : userid"
+            description = "쿠키 발급 : userid"
     )
     @ApiResponses({
-            @ApiResponse(code = 200, message = "API 정상 구동"),
+            @ApiResponse(code = 200, message = "로그인 완료"),
+            @ApiResponse(code = 401, message = "비밀번호 불일치\n해당 회원이 존재하지 않음"),
             @ApiResponse(code = 500, message = "서버 에러")
     })
     @GetMapping("signup")
-    public String signup(@RequestParam(value = "id") String userId,
-                         @RequestParam(value = "password") String password,
-                         HttpServletResponse servletResponse) throws NoSuchAlgorithmException {
+    public ResponseEntity<String> signup(@RequestParam(value = "id") String userId,
+                                         @RequestParam(value = "password") String password,
+                                         HttpServletResponse servletResponse) throws NoSuchAlgorithmException {
         JsonObject response = new JsonObject();
-        String crypto = sha256.encrypt(password);
 
-        Optional<User> user = userRepository.findById(userId);
+        if (authorize(userId, password, response)) {
+            User user = userRepository.findById(userId).orElseThrow();
 
-        if (user.isPresent()) {
-            if (crypto.equals(user.get().getUserPassword())) {
-                response.addProperty("success", "true");
-                log.info("User Login : " + user.get().getUserId());
-            } else {
-                response.addProperty("success", "failed");
-                response.addProperty("message", "Auth");
-            }
+            log.info("User Login : " + user.getUserId());
+
+            Cookie idCookie = new Cookie("userid", userId);
+            servletResponse.addCookie(idCookie);
+            return ResponseEntity.ok(response.toString());
         } else {
-            response.addProperty("success", "failed");
-            response.addProperty("message", "NoAccount");
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(response.toString());
         }
-
-        Cookie idCookie = new Cookie("userid", userId);
-        servletResponse.addCookie(idCookie);
-        return response.toString();
     }
 
     @Operation(
             summary = "사용자 탈퇴",
-            description = "탈퇴 성공여부 상태 리턴 (success true/failed)"
+            description = "서비스에서 탈퇴 합니다."
     )
+    @ApiResponses({
+            @ApiResponse(code = 204, message = "탈퇴 완료"),
+            @ApiResponse(code = 401, message = "비밀번호 불일치\n해당 회원이 존재하지 않음"),
+            @ApiResponse(code = 500, message = "서버 에러")
+    })
+    @ResponseStatus(value = HttpStatus.NO_CONTENT)
     @DeleteMapping("delete")
-    public String delete(@RequestParam(value = "id") String userId) {
+    public ResponseEntity<String> delete(@RequestParam(value = "id") String userId,
+                                         @RequestParam(value = "password") String password) throws NoSuchAlgorithmException {
         JsonObject response = new JsonObject();
-        try {
-            userRepository.deleteById(userId);
-            log.info("User Deleted : " + userId);
-            response.addProperty("success", "true");
-        } catch (Exception e) {
-            response.addProperty("success", "failed");
-            response.addProperty("message", e.getMessage());
-        }
 
-        return response.toString();
+        if (authorize(userId, password, response)) {
+            try {
+                userRepository.deleteById(userId);
+                log.info("User Deleted : " + userId);
+
+                return ResponseEntity.noContent().build();
+            } catch (Exception e) {
+                response.addProperty("message", e.getMessage());
+
+                return ResponseEntity.internalServerError().body(response.toString());
+            }
+        } else {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(response.toString());
+        }
     }
 
-    @ApiIgnore
+    /**
+     * @param userId   id
+     * @param password password
+     * @param response fail message (if success this will empty)
+     * @return true when authorized
+     */
+    private boolean authorize(@NotNull String userId,
+                              @NotNull String password,
+                              @NotNull JsonObject response) throws NoSuchAlgorithmException {
+        Optional<User> user = userRepository.findById(userId);
+        String crypto = sha256.encrypt(password);
+
+        if (user.isPresent()) {
+            if (crypto.equals(user.get().getUserPassword())) {
+                return true;
+            } else {
+                response.addProperty("message", "Invalid password: " + password);
+
+                return false;
+            }
+        } else {
+            response.addProperty("message", "No account: " + userId);
+
+            return false;
+        }
+    }
+
+    @Operation(
+            summary = "로그인 확인",
+            description = "로그인 되어 있는지 확인합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(code = 200, message = "로그인 되어 있음"),
+            @ApiResponse(code = 401, message = "로그인 되어 있지 않음")
+    })
     @GetMapping("check")
-    public String check(@CookieValue(name = "userid", required = false) String userId) {
+    public ResponseEntity<String> check(@CookieValue(name = "userid", required = false) String userId) {
         JsonObject response = new JsonObject();
         if (userId == null) {
-            response.addProperty("success", "false");
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
         } else {
-            response.addProperty("success", "true");
             response.addProperty("userID", userId);
-        }
 
-        return response.toString();
+            return ResponseEntity.ok(response.toString());
+        }
     }
 
     @Operation(
             summary = "로그아웃",
-            description = "로그아웃 성공여부 상태 리턴 (success true/failed)"
+            description = "로그아웃"
     )
     @GetMapping("logout")
-    public String logout(HttpServletResponse response) {
+    public ResponseEntity<String> logout(@NotNull HttpServletResponse response) {
         JsonObject json = new JsonObject();
 
         Cookie cookie = new Cookie("userid", null);
         cookie.setMaxAge(0);
         response.addCookie(cookie);
 
-        json.addProperty("success", "true");
-        return json.toString();
+        return ResponseEntity.ok(json.toString());
     }
 
 }

--- a/swServer/src/main/java/com/daelim/swserver/auth/entity/User.java
+++ b/swServer/src/main/java/com/daelim/swserver/auth/entity/User.java
@@ -43,4 +43,5 @@ public class User {
     public int hashCode() {
         return getClass().hashCode();
     }
+    
 }

--- a/swServer/src/main/resources/application.yml
+++ b/swServer/src/main/resources/application.yml
@@ -7,6 +7,7 @@ spring:
     database-platform: org.hibernate.dialect.PostgreSQLDialect
     open-in-view: false
     generate-ddl: true
+    
 logging:
   level:
     root: info


### PR DESCRIPTION
 * 성공 상태는 HTTP Response Code를 통해 전달되어야 하며, 필드에 success 를 정의해 전달하는 방법은 일반적인 REST API 설계에 위반됩니다.
 * 리소스가 아닌, 행위는 url 에 포함하지 않습니다. 일반적인 행위는 Http Method 를 통해 표현되어야 합니다.
 * Alarm의 delete 와 update 가 구현 되었습니다. **update는 RFC6902(https://www.rfc-editor.org/rfc/rfc6902) 를 따릅니다.**

> **Alarm update Example**
> alarmId: `5b0d4d5a-4825-42e7-a430-727ad6422b51`
> patch: `[ { "op": "replace", "path": "/repeat", "value": true } ]`

필드를 null 로 설정하면 삭제하게 하는 방법도 고려해보았으나 그렇게 하면 원래 Nullable인 필드는 null을 할당할 수 없어지기 때문에 표준을 사용합니다.